### PR TITLE
Make it possible to import epubs by open and share

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,19 @@
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.SEND" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<data android:mimeType="application/epub+zip" />
+			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:mimeType="application/epub+zip" />
+				<data android:scheme="content" />
+				<data android:scheme="file" />
+			</intent-filter>
 		</activity>
 		<activity android:name=".ui.screens.sourceCatalog.SourceCatalogActivity" />
 		<activity android:name=".ui.screens.chaptersList.ChaptersActivity" />

--- a/app/src/main/java/my/noveldokusha/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/my/noveldokusha/ui/screens/main/MainActivity.kt
@@ -1,5 +1,7 @@
 package my.noveldokusha.ui.screens.main
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -22,6 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import dagger.hilt.android.AndroidEntryPoint
 import my.noveldokusha.R
+import my.noveldokusha.services.EpubImportService
 import my.noveldokusha.ui.BaseActivity
 import my.noveldokusha.ui.composeViews.AnimatedTransition
 import my.noveldokusha.ui.screens.main.finder.FinderScreen
@@ -84,6 +87,30 @@ open class MainActivity : BaseActivity() {
                     }
                 }
             }
+        }
+
+        val action: String = intent.action!!
+        val type: String? = intent.type
+
+        if (Intent.ACTION_SEND == action && type != null) {
+            if ("application/epub+zip" == type) {
+                handleSharedEpub(intent)
+            }
+        } else if (Intent.ACTION_VIEW == action) {
+            handleViewedEpub(intent)
+        }
+    }
+
+    private fun handleViewedEpub(intent: Intent) {
+        val epubUri: Uri? = intent.data
+        if (epubUri != null) {
+            EpubImportService.start(ctx = this, uri = epubUri)
+        }
+    }
+    private fun handleSharedEpub(intent: Intent) {
+        val epubUri: Uri? = intent.getParcelableExtra(Intent.EXTRA_STREAM)
+        if (epubUri != null) {
+            EpubImportService.start(ctx = this, uri = epubUri)
         }
     }
 }

--- a/app/src/main/java/my/noveldokusha/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/my/noveldokusha/ui/screens/main/MainActivity.kt
@@ -89,15 +89,23 @@ open class MainActivity : BaseActivity() {
             }
         }
 
-        val action: String = intent.action!!
-        val type: String? = intent.type
+        handleIntent(intent)
+    }
 
-        if (Intent.ACTION_SEND == action && type != null) {
-            if ("application/epub+zip" == type) {
-                handleSharedEpub(intent)
+    private fun handleIntent(intent: Intent){
+        val action = intent.action ?: return
+        val type = intent.type
+
+        when (action) {
+            Intent.ACTION_SEND -> {
+                if (type == "application/epub+zip") {
+                    handleSharedEpub(intent)
+                }
             }
-        } else if (Intent.ACTION_VIEW == action) {
-            handleViewedEpub(intent)
+
+            Intent.ACTION_VIEW -> {
+                handleViewedEpub(intent)
+            }
         }
     }
 
@@ -107,6 +115,7 @@ open class MainActivity : BaseActivity() {
             EpubImportService.start(ctx = this, uri = epubUri)
         }
     }
+
     private fun handleSharedEpub(intent: Intent) {
         val epubUri: Uri? = intent.getParcelableExtra(Intent.EXTRA_STREAM)
         if (epubUri != null) {


### PR DESCRIPTION
This PR makes it possible to import epub files to the app using OPEN or SHARE. 
Meaning, you can click an epub file in your file browser, and get the option of importing it to NovelDokusha. 
Similarly, if you have an epub in an app with share functionality, you can share the epub to NovelDokusha. 