### PR TITLE
Remove anti-scrapping notices from the royal road scrapping results

### DIFF
--- a/scraper/src/main/java/my/noveldokusha/scraper/sources/RoyalRoad.kt
+++ b/scraper/src/main/java/my/noveldokusha/scraper/sources/RoyalRoad.kt
@@ -1,6 +1,5 @@
 package my.noveldokusha.scraper.sources
 
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import my.noveldokusha.core.LanguageCode
@@ -48,9 +47,9 @@ class RoyalRoad(
             .select("style")
             .flatMap { style -> cssPattern
                 .findAll(style.data())
-                .map { match -> match.groups["class"]!!.value } }
+                .map { match -> match.groups["class"]?.value }
+                .filterNotNull()}
             .toSet()
-        Log.v("RoyalRoadScrapper", "Found hidden CSS classes: $hiddenClasses")
         doc.selectFirst(".chapter-content")!!.let {
             it.select("script").remove()
             it.select("a").remove()


### PR DESCRIPTION
Currently chapters from RoyalRoad contain one paragraph with a message like

> If you encounter this story on Amazon, note that it's taken without permission from the author. Report it.

On the website this notice is hidden with a simple CSS rules like this:

```css
.cjNlMmQwM2QxYzVjMjRjOTlhMmI0ZTNkNmExODkwN2Qy{
    display: none;
    speak: never;
}
```
This PR add some code find rules like this and remove the respective elements from the HTML tree.